### PR TITLE
Fixing use of `getProgress()` default parameter

### DIFF
--- a/Sources/Shared/ActivityRingScene.swift
+++ b/Sources/Shared/ActivityRingScene.swift
@@ -142,7 +142,7 @@ final class ActivityRingScene: SKScene {
         }
         
         let now = CACurrentMediaTime()
-        animator = Animator(from: getProgress(atTime: now),
+        animator = Animator(from: getProgress(),
                             to: targetValue,
                             startTime: now,
                             duration: duration)


### PR DESCRIPTION
The `getProgress(:)` is a function that contains in its signature a declaration of its default parameter - `CACurrentMediaTime()` - and the same argument was being passed along the `getProgress(time: now)`.